### PR TITLE
chore(ng-update): update angular dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,9 +12,9 @@
         "karma": "^6.4.2"
       },
       "devDependencies": {
-        "@angular-devkit/build-angular": "^17.0.8",
+        "@angular-devkit/build-angular": "^17.0.9",
         "@angular/animations": "17.0.8",
-        "@angular/cli": "^17.0.8",
+        "@angular/cli": "^17.0.9",
         "@angular/common": "17.0.8",
         "@angular/compiler": "17.0.8",
         "@angular/compiler-cli": "17.0.8",
@@ -49,12 +49,12 @@
       }
     },
     "node_modules/@angular-devkit/architect": {
-      "version": "0.1700.8",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1700.8.tgz",
-      "integrity": "sha512-SWVr3CvwO6T0yW2ytszCwBT1g92vyFkwbVUxqE93urYnoD8PvP+81GH5YwVjHQTgvhP4eXQMGZ9hpHx57VOrWQ==",
+      "version": "0.1700.9",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1700.9.tgz",
+      "integrity": "sha512-B8OeUrvJj5JsfOJIibpoVjvuZzthPFxf1LvuUXTyQcqDUscJAe/RJBc2woT6ss13Iv/HWt8mgaMPP4CccckdNg==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/core": "17.0.8",
+        "@angular-devkit/core": "17.0.9",
         "rxjs": "7.8.1"
       },
       "engines": {
@@ -64,15 +64,15 @@
       }
     },
     "node_modules/@angular-devkit/build-angular": {
-      "version": "17.0.8",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-17.0.8.tgz",
-      "integrity": "sha512-u7R5yX92ZxOL/LfxiKGGqlBo86100sJ5Rabavn8DeGtYP8N0qgwCcNwlW2zaMoUlkw2geMnxcxIX5VJI4iFPUA==",
+      "version": "17.0.9",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-17.0.9.tgz",
+      "integrity": "sha512-yH6AfR2/CXrp05dIFQCroyl6Eaq8mS6tt4P7yS48+KXvAbQq2KzYW+TrDD4flFXe3qLVQGFpds3jE2auiwhHsA==",
       "dev": true,
       "dependencies": {
         "@ampproject/remapping": "2.2.1",
-        "@angular-devkit/architect": "0.1700.8",
-        "@angular-devkit/build-webpack": "0.1700.8",
-        "@angular-devkit/core": "17.0.8",
+        "@angular-devkit/architect": "0.1700.9",
+        "@angular-devkit/build-webpack": "0.1700.9",
+        "@angular-devkit/core": "17.0.9",
         "@babel/core": "7.23.2",
         "@babel/generator": "7.23.0",
         "@babel/helper-annotate-as-pure": "7.22.5",
@@ -83,7 +83,7 @@
         "@babel/preset-env": "7.23.2",
         "@babel/runtime": "7.23.2",
         "@discoveryjs/json-ext": "0.5.7",
-        "@ngtools/webpack": "17.0.8",
+        "@ngtools/webpack": "17.0.9",
         "@vitejs/plugin-basic-ssl": "1.0.1",
         "ansi-colors": "4.1.3",
         "autoprefixer": "10.4.16",
@@ -616,12 +616,12 @@
       }
     },
     "node_modules/@angular-devkit/build-webpack": {
-      "version": "0.1700.8",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.1700.8.tgz",
-      "integrity": "sha512-GA7QlCAlYB3uBkRaUYgIC/Vfajb9jMmouwYiAAEm34ZyP3ThFjdqsYd/A/exnuESt5o6Bh++C/PI34sV3lawRA==",
+      "version": "0.1700.9",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.1700.9.tgz",
+      "integrity": "sha512-NBpTb5kdnTePtNirsJQFXfOIFKTPdDqJe0b0sI3FI860po7uvUFu1m5pL5QSkJLmdqrjfPkNq7svGf7NlHQ8JA==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/architect": "0.1700.8",
+        "@angular-devkit/architect": "0.1700.9",
         "rxjs": "7.8.1"
       },
       "engines": {
@@ -635,9 +635,9 @@
       }
     },
     "node_modules/@angular-devkit/core": {
-      "version": "17.0.8",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-17.0.8.tgz",
-      "integrity": "sha512-gI8+SOwGUwr0WOlFrhLjohLolMzcguuoR0LTZEcGjdXvQyPgH4NDSRIIrfWCdu+ZVhfy76o3zQYdYc9QN8NrjQ==",
+      "version": "17.0.9",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-17.0.9.tgz",
+      "integrity": "sha512-r5jqwpWOgowqe9KSDqJ3iSbmsEt2XPjSvRG4DSI2T9s31bReoMtreo8b7wkRa2B3hbcDnstFbn8q27VvJDqRaQ==",
       "dev": true,
       "dependencies": {
         "ajv": "8.12.0",
@@ -674,12 +674,12 @@
       }
     },
     "node_modules/@angular-devkit/schematics": {
-      "version": "17.0.8",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-17.0.8.tgz",
-      "integrity": "sha512-syo814SVWfJvne448IijjZvpWbuqJsEutdNqHWLTewTfX2U3KrIAr/XRVcXQMuyMvLCDiuxjMgEJxOIP7mcIPw==",
+      "version": "17.0.9",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-17.0.9.tgz",
+      "integrity": "sha512-5ti7g45F2KjDJS0DbgnOGI1GyKxGpn4XsKTYJFJrSAWj6VpuvPy/DINRrXNuRVo09VPEkqA+IW7QwaG9icptQg==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/core": "17.0.8",
+        "@angular-devkit/core": "17.0.9",
         "jsonc-parser": "3.2.0",
         "magic-string": "0.30.5",
         "ora": "5.4.1",
@@ -707,15 +707,15 @@
       }
     },
     "node_modules/@angular/cli": {
-      "version": "17.0.8",
-      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-17.0.8.tgz",
-      "integrity": "sha512-yZXYNLAFv9u2qypsVqtS+rRCsnjsIPYXr6TcI/r5buzOtC7UQ2lleYsWJqX47SsyGMk/o3gaYg5Bj2I5mmRDLA==",
+      "version": "17.0.9",
+      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-17.0.9.tgz",
+      "integrity": "sha512-a1rLAu3TNU5d56ozBnx9UZchJDKC8qMvZL4ThJhcaTUJb0Cj//gqLJdNdMcB0p1Ve9lmmAQ3J17+2Xij1u3sNg==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/architect": "0.1700.8",
-        "@angular-devkit/core": "17.0.8",
-        "@angular-devkit/schematics": "17.0.8",
-        "@schematics/angular": "17.0.8",
+        "@angular-devkit/architect": "0.1700.9",
+        "@angular-devkit/core": "17.0.9",
+        "@angular-devkit/schematics": "17.0.9",
+        "@schematics/angular": "17.0.9",
         "@yarnpkg/lockfile": "1.1.0",
         "ansi-colors": "4.1.3",
         "ini": "4.1.1",
@@ -3258,9 +3258,9 @@
       }
     },
     "node_modules/@ngtools/webpack": {
-      "version": "17.0.8",
-      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-17.0.8.tgz",
-      "integrity": "sha512-wx0XBMrbpDeailK2uIhp/ZVMC3GK3BWwJjUu5SbT4BFrcoi2Zd9/9m0RCBAY54UXLBCqKd+ih7pJ6JSvprZmWw==",
+      "version": "17.0.9",
+      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-17.0.9.tgz",
+      "integrity": "sha512-ilbzwW30NaccrhYbdY3jy/ZpbC0l7W6+L2Cd3dzHFQ1gZGckibDdMzjibW/vyq/vRf0xr25+oBVIqUn8kZ606g==",
       "dev": true,
       "engines": {
         "node": "^18.13.0 || >=20.9.0",
@@ -3642,13 +3642,13 @@
       ]
     },
     "node_modules/@schematics/angular": {
-      "version": "17.0.8",
-      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-17.0.8.tgz",
-      "integrity": "sha512-1h5mwKFv1B/L5JWZ0mxnC4ms06iwnSi/w+GgRZPeM3P5BpuZuvAkFiClNnM55iLlQJXRQioPNLM3sOsz7spR6w==",
+      "version": "17.0.9",
+      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-17.0.9.tgz",
+      "integrity": "sha512-XPaHAhobxdQMswH8wSrfToKN7wmGJFh/K5jq/3J+78KeSBZStYxZkVIQbvJkSU8Y1MsdVaeMYKDE8rjFN83OYA==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/core": "17.0.8",
-        "@angular-devkit/schematics": "17.0.8",
+        "@angular-devkit/core": "17.0.9",
+        "@angular-devkit/schematics": "17.0.9",
         "jsonc-parser": "3.2.0"
       },
       "engines": {
@@ -3893,9 +3893,9 @@
       "integrity": "sha512-xA6drNNeqb5YyV5fO3OAEsnXLfO7uF0whiOfPTz5AeDo8KeZFmODKnvwPymMNO8qE/an8pVY/O50tig2SQCrGw=="
     },
     "node_modules/@types/node-forge": {
-      "version": "1.3.10",
-      "resolved": "https://registry.npmjs.org/@types/node-forge/-/node-forge-1.3.10.tgz",
-      "integrity": "sha512-y6PJDYN4xYBxwd22l+OVH35N+1fCYWiuC3aiP2SlXVE6Lo7SS+rSx9r89hLxrP4pn6n1lBGhHJ12pj3F3Mpttw==",
+      "version": "1.3.11",
+      "resolved": "https://registry.npmjs.org/@types/node-forge/-/node-forge-1.3.11.tgz",
+      "integrity": "sha512-FQx220y22OKNTqaByeBGqHWYz4cl94tpcxeFdvBo3wjG6XPBuZ0BNgNZRV5J5TFmmcsJ4IzsLkmGRiQbnYsBEQ==",
       "dev": true,
       "dependencies": {
         "@types/node": "*"
@@ -4372,9 +4372,9 @@
       }
     },
     "node_modules/array-flatten": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-2.1.2.tgz",
-      "integrity": "sha512-hNfzcOV8W4NdualtqBFPyVO+54DSJuZGY9qT4pRroB6S9e3iiido2ISIC5h9R2sPJ8H3FHCIiEnsv1lPXO3KtQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
       "dev": true
     },
     "node_modules/async": {
@@ -4778,13 +4778,11 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
     },
     "node_modules/bonjour-service": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/bonjour-service/-/bonjour-service-1.1.1.tgz",
-      "integrity": "sha512-Z/5lQRMOG9k7W+FkeGTNjh7htqn/2LMnfOvBZ8pynNZCM9MwkQkI3zeI4oz09uWdcgmgHugVvBqxGg4VQJ5PCg==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/bonjour-service/-/bonjour-service-1.2.0.tgz",
+      "integrity": "sha512-xdzMA6JGckxyJzZByjEWRcfKmDxXaGXZWVftah3FkCqdlePNS9DjHSUN5zkP4oEfz/t0EXXlro88EIhzwMB4zA==",
       "dev": true,
       "dependencies": {
-        "array-flatten": "^2.1.2",
-        "dns-equal": "^1.0.0",
         "fast-deep-equal": "^3.1.3",
         "multicast-dns": "^7.2.5"
       }
@@ -6208,12 +6206,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/dns-equal": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/dns-equal/-/dns-equal-1.0.0.tgz",
-      "integrity": "sha512-z+paD6YUQsk+AbGCEM4PrOXSss5gd66QfcVBFTKR/HpFL9jCqikS94HYwKww6fQyO7IxrIIyUu+g0Ka9tUS2Cg==",
-      "dev": true
-    },
     "node_modules/dns-packet": {
       "version": "5.6.1",
       "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-5.6.1.tgz",
@@ -6820,12 +6812,6 @@
       "engines": {
         "node": ">= 0.10.0"
       }
-    },
-    "node_modules/express/node_modules/array-flatten": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
-      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
-      "dev": true
     },
     "node_modules/express/node_modules/debug": {
       "version": "2.6.9",
@@ -13117,9 +13103,9 @@
       }
     },
     "node_modules/webpack-dev-server/node_modules/ws": {
-      "version": "8.15.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.15.1.tgz",
-      "integrity": "sha512-W5OZiCjXEmk0yZ66ZN82beM5Sz7l7coYxpRkzS+p9PP+ToQry8szKh+61eNktr7EA9DOwvFGhfC605jDHbP6QQ==",
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.16.0.tgz",
+      "integrity": "sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ==",
       "dev": true,
       "engines": {
         "node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -32,9 +32,9 @@
   },
   "homepage": "https://github.com/fast-facts/ngx-bootstrap-multiselect.git",
   "devDependencies": {
-    "@angular-devkit/build-angular": "^17.0.8",
+    "@angular-devkit/build-angular": "^17.0.9",
     "@angular/animations": "17.0.8",
-    "@angular/cli": "^17.0.8",
+    "@angular/cli": "^17.0.9",
     "@angular/common": "17.0.8",
     "@angular/compiler": "17.0.8",
     "@angular/compiler-cli": "17.0.8",


### PR DESCRIPTION
[ng-update](https://github.com/fast-facts/ng-update) 🤖 has automatically run `ng update` for you and baked this hot 🔥 PR , ready to merge.

<details>
  <summary>Ng Update Output:</summary>

    Using package manager: npm
Collecting installed dependencies...
Found 22 dependencies.
    We analyzed your package.json, there are some packages to update:
    
      Name                               Version                  Command to update
     --------------------------------------------------------------------------------
      @angular/cli                       17.0.8 -> 17.0.9         ng update @angular/cli
    
    There might be additional packages which don't provide 'ng update' capabilities that are outdated.
    You can update the additional packages by running the update command of your package manager.


  </summary>
</details>